### PR TITLE
Addition of notes endpoint and object, addition of properties to obswell object

### DIFF
--- a/sageodata-apispec.yml
+++ b/sageodata-apispec.yml
@@ -2206,6 +2206,7 @@ components:
     obswell:
       title: Root Type for obswell
       description: A monitored waterwell.
+      required: []
       type: object
       properties:
         unitNumber:
@@ -2234,31 +2235,12 @@ components:
           description: A unique number identifying the obswell on the 1:100000 map
             sheet for which the obswell is located.
           type: integer
-        latitude:
-          format: double
-          description: Latitude of the obswell.
-          type: number
-        longitude:
-          format: double
-          description: Longitude of the obswell.
-          type: number
-        easting:
-          format: double
-          description: Easting of the obswell.
-          type: number
-        northing:
-          format: double
-          description: Norting of the obswell.
-          type: number
         obsWellPlan:
           description: A unique code for the plan (hundred) on which an obswell is
             located.
           type: string
         obsWellSequenceNumber:
           description: A unique number identifying the obswell on the obsWellPlan.
-          type: string
-        zone:
-          description: Zone of the obswell.
           type: string
         aquiferIntersected:
           description: Code identifying the aquifer that the well intersects.
@@ -2322,7 +2304,114 @@ components:
           description: Prescribed water resource area
           type: string
         monitoringNetworks:
-          description: Monitoring networks to which the obswell is assigned.
+          description: |-
+            Monitoring networks to which the obswell is assigned. Possible values:
+
+            Angas Bremer PWA
+
+            Barossa PWRA
+
+            Clare PWRA
+
+            Leigh Creek
+
+            Loxton - Bookpurnong Irrigation Areas
+
+            Mallee PWA
+
+            Marla Township
+
+            Marne River and Saunders Creek PWRA
+
+            Tatiara PWA
+
+            Chowilla Floodplain
+
+            Padthaway PWA
+
+            Northern Adelaide Plains PWA
+
+            Katarapko Floodplain Injection
+
+            EPNRM Groundwater Dependent Ecosystem wells
+
+            SA Water Waikerie SIS
+
+            Baroota PWRA
+
+            Pike and Murtho Irrigation Areas
+
+            Lower Limestone Coast PWA_South
+
+            Western Mount Lofty Ranges PWRA
+
+            Northern Adelaide Plains PWA irrigation wells salinity monitoring
+
+            Peake, Roby and Sherlock PWA
+
+            Kangaroo Flat irrigation wells salinity monitoring
+
+            Lower Limestone Coast PWA_North
+
+            Golden Grove extractive indust zone
+
+            Barossa irrigation wells salinity monitoring
+
+            McLaren Vale  PWA irrigation wells salinity monitoring
+
+            SA Water Town Water Supplies salinity monitoring
+
+            Botanic Gardens wetlands
+
+            Tintinara Coonalpyn PWA
+
+            South East Non-Prescribed Area
+
+            SA Murray Darling Basin Non-Prescribed Area
+
+            Kangaroo Island Non-Prescribed Area
+
+            Musgrave PWA
+
+            Southern Basins PWA
+
+            Eyre Peninsula Non-Prescribed Area
+
+            SA Arid Lands Non-Prescribed Area
+
+            Alinytjara Wilurara Non-Prescribed Area
+
+            Far North PWA
+
+            Northern & Yorke Non-Prescribed Area - NORTH
+
+            Northern & Yorke Non-Prescribed Area - SOUTH
+
+            Central Adelaide PWA
+
+            McLaren Vale PWA
+
+            Streaky Bay Non-Prescribed Area
+
+            Berri and Renmark Irrigation Areas
+
+            Northern Adelaide Plains Perched Aquifers
+
+            Katarapko Floodplain
+
+            Pike Floodplain
+
+            Eastern Mount Lofty Ranges PWRA
+
+            Noora Disposal Basin
+
+            Waikerie Moorook Irrigation Areas
+
+            SA Murray Darling Basin - SA Water
+
+            SE Flows Restoration Project
+
+            SA Water Murtho SIS
           type: array
           items:
             type: string
@@ -2349,6 +2438,9 @@ components:
           - TINCNP
           - DRYCK
           type: string
+        coordinates:
+          $ref: '#/components/schemas/coordinatedata'
+          description: Coordinate date for the obswell.
       example:
         drillholeNumber: 230
         drillholeName: A-29 (MT DAVIES)

--- a/sageodata-apispec.yml
+++ b/sageodata-apispec.yml
@@ -681,6 +681,38 @@ paths:
                     DIG\",\r\n    \"Value\": \"Digitised\"\r\n  }\r\n]"
           description: Successful operation
       summary: List all survey methods
+  /api/v1.0/obswells/{id}/notes/:
+    summary: Endpoint to interact with the list of notes for a single obswell.
+    description: ""
+    get:
+      tags:
+      - obswell
+      parameters:
+      - name: modifiedSince
+        description: If specified, only notes that have been modified more recently
+          than the supplied value will be returned.
+        schema:
+          format: date-time
+          type: string
+        in: query
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/note-page'
+          description: Successful operation
+      operationId: GetNotes
+      summary: List all notes
+      description: ""
+    parameters:
+    - name: id
+      description: DrillholeId specifying which obswell to retrieve notes for.
+      schema:
+        format: int64
+        type: integer
+      in: path
+      required: true
 components:
   schemas:
     address:
@@ -1921,56 +1953,6 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/obswell'
-    waterlevelmeasurement:
-      title: Root Type for waterlevelmeasurement
-      description: Data type representing a water level measurement recorded during
-        a field visit to an obswell.
-      type: object
-      properties:
-        measurementDate:
-          format: date-time
-          description: Date the measurement was taken.
-          type: string
-        depthToWater:
-          format: double
-          description: The actual Depth to Water measurment value.
-          type: number
-        comments:
-          description: Comments
-          type: string
-        agencyResponsible:
-          description: Agency responsible for the measurement.
-          type: string
-        conductedBy:
-          description: The username of the field officer(s) who conducted the field
-            visit.
-          type: string
-        createdDate:
-          format: date-time
-          description: Date the measurement was added to SAGeoData.
-          type: string
-        modifiedDate:
-          format: date-time
-          description: Datetime of the most recent modification to the measurement
-            in SAGeoData.
-          type: string
-        measurementNumber:
-          format: int32
-          description: Unique identifier of the measurement specified by SAGeoData.
-          type: integer
-        drillholeNumber:
-          format: int32
-          description: Unique identifier of drillhole specified by SAGeoData.
-          type: integer
-      example:
-        drillholeNumber: 4
-        measurementNumber: 1
-        measurementDate: 1990-12-06T00:00:00.000Z
-        depthToWater: 71.6
-        agencyResponsible: DEWNR
-        conductedBy: DHDB
-        createdDate: 1997-07-02T18:23:52.000Z
-        modifiedDate: 2012-09-20T15:56:31.000Z
     waterlevelmeasurement-page:
       description: Data type that represents a collection/page of water level measurements.
       required:
@@ -2184,129 +2166,6 @@ components:
         Code:
           description: Code for the associated value.
           type: string
-    obswell:
-      title: Root Type for obswell
-      description: A monitored waterwell.
-      type: object
-      properties:
-        unitNumber:
-          format: int32
-          description: A combination of the map100000Number and sequence number.
-          type: integer
-        nrmRegionCode:
-          description: "NRM region code. Possible values:\n\n`OUT` Out of NRM regions\n\
-            \n`AMLR`\tAdelaide & Mt Lofty Ranges\n\n`ATJWIL`Alinytjara Wilurara\n\n\
-            `EYRPEN`Eyre Peninsula\n\n`KI` Kangaroo Island\n\n`NTHYK`\tNorthern &\
-            \ Yorke\n\n`SAARDL` South Australian Arid Lands\n\n`STHEAST` South East\n\
-            \n`SAMDB`\tSouth Australian Murray-Darling Basin\n"
-          enum:
-          - ANGBRM
-          - CTRADL
-          - FRNTH
-          - LWRLC
-          - MAL
-          - MCLVAL
-          - MGRV
-          - NOO
-          - NTHADLPL
-          - PAD
-          - PKRBSHR
-          - STHBAS
-          - TAT
-          - TINCNP
-          - DRYCK
-          type: string
-        sequenceNumber:
-          format: int32
-          description: A unique number identifying the obswell on the 1:100000 map
-            sheet for which the obswell is located.
-          type: integer
-        latitude:
-          format: double
-          description: Latitude of the obswell.
-          type: number
-        longitude:
-          format: double
-          description: Longitude of the obswell.
-          type: number
-        obsWellPlan:
-          description: A unique code for the plan (hundred) on which an obswell is
-            located.
-          type: string
-        obsWellSequenceNumber:
-          description: A unique number identifying the obswell on the obsWellPlan.
-          type: string
-        aquiferIntersected:
-          description: Code identifying the aquifer that the well intersects.
-          type: string
-        comments:
-          description: Comments
-          type: string
-        createdDate:
-          format: date-time
-          description: Date the obswell was added to SAGeoData.
-          type: string
-        modifiedDate:
-          format: date-time
-          description: Datetime of the most recent modification to the obswell in
-            SAGeoData.
-          type: string
-        name:
-          description: Name of the obswell.
-          type: string
-        elevationMeasurementsURL:
-          description: URL to API endpoint to retrieve elevation measurements for
-            the obswell.
-          type: string
-        waterLevelMeasurementsURL:
-          description: URL to API endpoint to retrieve water level measurements for
-            the obswell.
-          type: string
-        map100kNumber:
-          format: int32
-          description: The 1:100000 map sheet number on which an obswell is located.
-            Unique per 1:100000 map sheet. Generated by SAGeoData upon entry of coordinates
-            into SAGeoData.
-          type: integer
-        drillholeNumber:
-          format: int32
-          description: Unique identifier specified by SAGeoData.
-          type: integer
-        nrmRegion:
-          description: NRM region
-          type: string
-        status:
-          description: "Status of the drillhole. Possible values are:\r\n\r\n\r\n\
-            Abandoned\t\r\nBackfilled\t\r\nBlocked\t\r\nCapped\t\r\nCare and Maintenance\t\
-            \r\nCased\t\r\nCollapsed\t\r\nCompleted\t\r\nControlled - shut in\t\r\n\
-            Controlled Flowing\t\r\nConverted to WW\t\r\nDamaged\t\r\nDamp\t\r\nDecommissioned\t\
-            \r\nDry\t\r\nDual Completion\t\r\nEquipped (pump, windmill, etc)\t\r\n\
-            Extinct Spring\t\r\nFlowing\t\r\nFree water and tail\t\r\nGeotechnically\
-            \ Equiped\t\r\nInjector\t\r\nMined (removed by mining)\t\r\nNot Equipped\t\
-            \r\nNot In Use\t\r\nNot Located\t\r\nNot Operational\t\r\nOperational\t\
-            \r\nOperational as required\t\r\nPlugged\t\r\nPond, free water\t\r\nRehabilitated\t\
-            \r\nSaturated\t\r\nShut In\t\r\nSingle Completion\t\r\nStorage\t\r\nSuspended\t\
-            \r\nUncontrolled Flowing\t\r\nUnequipped\t\r\nUnknown\t\r\nUnworked"
-          type: string
-        prescribedWellAreaName:
-          description: Prescribed well area
-          type: string
-        prescribedWaterResourceAreaName:
-          description: Prescribed water resource area
-          type: string
-      example:
-        drillholeNumber: 230
-        drillholeName: A-29 (MT DAVIES)
-        unitNumber: 474500070
-        nrmRegionCode: Alinytjara Wilurara
-        waterWellClass: "N"
-        map100000Number: 4745
-        sequenceNumber: 70
-        latitude: -26.1130886
-        longitude: 129.02301
-        comments: South Western Mining Company
-        createdDate: 1992-12-10T18:04:24.000Z
-        modifiedDate: 2019-08-30T09:32:00.000Z
     wcr-constructiondata:
       description: Well Completion Report - Construction Data
       required:
@@ -2349,6 +2208,270 @@ components:
         permitHolderName:
           description: Permit Holder Name
           type: string
+    waterlevelmeasurement:
+      title: Root Type for waterlevelmeasurement
+      description: Data type representing a water level measurement recorded during
+        a field visit to an obswell.
+      type: object
+      properties:
+        measurementDate:
+          format: date-time
+          description: Date the measurement was taken.
+          type: string
+        depthToWater:
+          format: double
+          description: The  Depth to Water measurment value.
+          type: number
+        artesianPressure:
+          format: double
+          description: The Artesian Pressure measurment value.
+          type: number
+        comments:
+          description: Comments
+          type: string
+        agencyResponsible:
+          description: Agency responsible for the measurement.
+          type: string
+        conductedBy:
+          description: The username of the field officer(s) who conducted the field
+            visit.
+          type: string
+        createdDate:
+          format: date-time
+          description: Date the measurement was added to SAGeoData.
+          type: string
+        modifiedDate:
+          format: date-time
+          description: Datetime of the most recent modification to the measurement
+            in SAGeoData.
+          type: string
+        measurementNumber:
+          format: int32
+          description: Unique identifier of the measurement specified by SAGeoData.
+          type: integer
+        drillholeNumber:
+          format: int32
+          description: Unique identifier of drillhole specified by SAGeoData.
+          type: integer
+      example:
+        drillholeNumber: 4
+        measurementNumber: 1
+        measurementDate: 1990-12-06T00:00:00.000Z
+        depthToWater: 71.6
+        artesianPressure: 10
+        agencyResponsible: DEWNR
+        conductedBy: DHDB
+        createdDate: 1997-07-02T18:23:52.000Z
+        modifiedDate: 2012-09-20T15:56:31.000Z
+    note:
+      title: Root Type for note
+      description: A note, for example a note for an obswell.
+      type: object
+      properties:
+        createdBy:
+          description: SAGeoData username of the user who created the note.
+          type: string
+        note:
+          description: The note text.
+          type: string
+        noteDate:
+          format: date-time
+          description: The date of the note.
+          type: string
+        noteId:
+          format: int32
+          description: Unique identifier of the note.
+          type: integer
+      example:
+        noteId: 10000
+        note: note text here
+        noteDate: 2020-09-02 00:00
+        createdBy: KINVERARITY
+    note-page:
+      description: Data type that represents a collection/page of notes
+      required:
+      - results
+      type: object
+      properties:
+        nextPage:
+          description: URI to next page of the collection
+          type: string
+        prevPage:
+          description: URI to previous page of the collection
+          type: string
+        totalRecords:
+          description: Indicates the total number of records (including all pages)
+          type: integer
+        pageSize:
+          description: Number of records displayed per page
+          type: integer
+        pageNumber:
+          description: Index (1-based) respresenting current page number
+          type: integer
+        results:
+          description: Collection of notes.
+          type: array
+          items:
+            $ref: '#/components/schemas/note'
+    obswell:
+      title: Root Type for obswell
+      description: A monitored waterwell.
+      type: object
+      properties:
+        unitNumber:
+          format: int32
+          description: A combination of the map100000Number and sequence number.
+          type: integer
+        landscapeSARegionCode:
+          description: "Landscape SA Region Code. Possible values:\n\n`ALTJWIL` Alinytjara\
+            \ Wilurara \n`EYRPEN` Eyre Peninsula \n`GRNADL` Green Adelaide \n`HILFLE`\
+            \ Hills and Fleurieu \n`KI` Kangaroo Island \n`LC` Limestone Coast \n\
+            `MURRIV` Murraylands and Riverland \n`NTHYK` Northern and Yorke\n`SAARDL`\
+            \ South Australian Arid Lands "
+          enum:
+          - ALTJWIL
+          - EYRPEN
+          - GRNADL
+          - HILFLE
+          - KI
+          - LC
+          - MURRIV
+          - NTHYK
+          - SAARDL
+          type: string
+        sequenceNumber:
+          format: int32
+          description: A unique number identifying the obswell on the 1:100000 map
+            sheet for which the obswell is located.
+          type: integer
+        latitude:
+          format: double
+          description: Latitude of the obswell.
+          type: number
+        longitude:
+          format: double
+          description: Longitude of the obswell.
+          type: number
+        easting:
+          format: double
+          description: Easting of the obswell.
+          type: number
+        northing:
+          format: double
+          description: Norting of the obswell.
+          type: number
+        obsWellPlan:
+          description: A unique code for the plan (hundred) on which an obswell is
+            located.
+          type: string
+        obsWellSequenceNumber:
+          description: A unique number identifying the obswell on the obsWellPlan.
+          type: string
+        zone:
+          description: Zone of the obswell.
+          type: string
+        aquiferIntersected:
+          description: Code identifying the aquifer that the well intersects.
+          type: string
+        hundreds:
+          description: Hundreds of the obswell.
+          type: string
+        comments:
+          description: Comments
+          type: string
+        createdDate:
+          format: date-time
+          description: Date the obswell was added to SAGeoData.
+          type: string
+        modifiedDate:
+          format: date-time
+          description: Datetime of the most recent modification to the obswell in
+            SAGeoData.
+          type: string
+        name:
+          description: Name of the obswell.
+          type: string
+        elevationMeasurementsURL:
+          description: URL to API endpoint to retrieve elevation measurements for
+            the obswell.
+          type: string
+        notesURL:
+          description: URL to API endpoint to retrieve notes for the obswell.
+          type: string
+        waterLevelMeasurementsURL:
+          description: URL to API endpoint to retrieve water level measurements for
+            the obswell.
+          type: string
+        map100kNumber:
+          format: int32
+          description: The 1:100000 map sheet number on which an obswell is located.
+            Unique per 1:100000 map sheet. Generated by SAGeoData upon entry of coordinates
+            into SAGeoData.
+          type: integer
+        drillholeNumber:
+          format: int32
+          description: Unique identifier specified by SAGeoData.
+          type: integer
+        status:
+          description: "Status of the drillhole. Possible values are:\r\n\r\n\r\n\
+            Abandoned\t\r\nBackfilled\t\r\nBlocked\t\r\nCapped\t\r\nCare and Maintenance\t\
+            \r\nCased\t\r\nCollapsed\t\r\nCompleted\t\r\nControlled - shut in\t\r\n\
+            Controlled Flowing\t\r\nConverted to WW\t\r\nDamaged\t\r\nDamp\t\r\nDecommissioned\t\
+            \r\nDry\t\r\nDual Completion\t\r\nEquipped (pump, windmill, etc)\t\r\n\
+            Extinct Spring\t\r\nFlowing\t\r\nFree water and tail\t\r\nGeotechnically\
+            \ Equiped\t\r\nInjector\t\r\nMined (removed by mining)\t\r\nNot Equipped\t\
+            \r\nNot In Use\t\r\nNot Located\t\r\nNot Operational\t\r\nOperational\t\
+            \r\nOperational as required\t\r\nPlugged\t\r\nPond, free water\t\r\nRehabilitated\t\
+            \r\nSaturated\t\r\nShut In\t\r\nSingle Completion\t\r\nStorage\t\r\nSuspended\t\
+            \r\nUncontrolled Flowing\t\r\nUnequipped\t\r\nUnknown\t\r\nUnworked"
+          type: string
+        prescribedWellAreaName:
+          description: Prescribed well area
+          type: string
+        prescribedWaterResourceAreaName:
+          description: Prescribed water resource area
+          type: string
+        monitoringNetworks:
+          description: Monitoring networks to which the obswell is assigned.
+          type: array
+          items:
+            type: string
+        nrmRegion:
+          description: "NRM region code. Possible values:\n\n`OUT` Out of NRM regions\n\
+            \n`AMLR`\tAdelaide & Mt Lofty Ranges\n\n`ATJWIL`Alinytjara Wilurara\n\n\
+            `EYRPEN`Eyre Peninsula\n\n`KI` Kangaroo Island\n\n`NTHYK`\tNorthern &\
+            \ Yorke\n\n`SAARDL` South Australian Arid Lands\n\n`STHEAST` South East\n\
+            \n`SAMDB`\tSouth Australian Murray-Darling Basin\n"
+          enum:
+          - ANGBRM
+          - CTRADL
+          - FRNTH
+          - LWRLC
+          - MAL
+          - MCLVAL
+          - MGRV
+          - NOO
+          - NTHADLPL
+          - PAD
+          - PKRBSHR
+          - STHBAS
+          - TAT
+          - TINCNP
+          - DRYCK
+          type: string
+      example:
+        drillholeNumber: 230
+        drillholeName: A-29 (MT DAVIES)
+        unitNumber: 474500070
+        nrmRegionCode: Alinytjara Wilurara
+        waterWellClass: "N"
+        map100000Number: 4745
+        sequenceNumber: 70
+        latitude: -26.1130886
+        longitude: 129.02301
+        comments: South Western Mining Company
+        createdDate: 1992-12-10T18:04:24.000Z
+        modifiedDate: 2019-08-30T09:32:00.000Z
   responses:
     UnauthorizedError:
       headers:

--- a/sageodata-apispec.yml
+++ b/sageodata-apispec.yml
@@ -713,6 +713,25 @@ paths:
         type: integer
       in: path
       required: true
+  /api/v1.0/monitoringNetworks:
+    summary: Endpoint to return a list of available monitoring networks
+    get:
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/monitoringNetwork'
+              examples:
+                Angus Bremer Example:
+                  value:
+                    monitoringNetworkCode: ANGBRM
+                    monitoringNetworkName: Angas Bremer PWA
+          description: Success
+      operationId: GetMonitoringNetworks
+      summary: Get available Monitoring Networks
 components:
   schemas:
     address:
@@ -2573,6 +2592,55 @@ components:
           - UKN
           - VERBL
           type: string
+    monitoringNetwork:
+      title: Root Type for monitoringNetwork
+      description: A monitoring network that an obswell may belong to
+      type: object
+      properties:
+        monitoringNetworkCode:
+          description: "Code of monitoring network. Possible values:\n\nANGBRM \n\n\
+            BAROSSA\n\nCLARE\n\nLEIGHCK\n\nLOXTON\n\nMALLEE\n\nMARLA\n\nMARNE\n\n\
+            TATIARA\n\nCHOWILLA\n\nPADTH\n\nNAP\n\nKAT_FP_INJ\n\nEP_GDE\n\nSAW_WAIK\n\
+            \nBAROOTA\n\nPIKEMURTHO\n\nLLC_STH\n\nWMLR\n\nNAP_LIC\n\nPEAKE\n\nKANGFLAT\n\
+            \nLLC_NTH\n\nGG_EIZ\n\nBAROSS_IRR\n\nMV_IRR_TDS\n\nSA_TWS\n\nBOT_GDNS\n\
+            \nTINT_COON\n\nSE_NP\n\nSAMDB_NP\n\nKI_NP\n\nMUSGRAVE\n\nSTHNBASINS\n\n\
+            EP_NP\n\nSAAL_NP\n\nAW_NP\n\nFAR NORTH\n\nNY_NP_NTH\n\nNY_NP_STH\n\nCENT_ADEL\n\
+            \nMCL_VALE\n\nEP_STREAKY\n\nBERI_REN\n\nNAP_PERCH\n\nKAT_FP\n\nPIKE_FP\n\
+            \nEMLR\n\nNOORA_SAW\n\nWAK_MRK\n\nSAMDB_SAW\n\nSEFRP\n\nSAW_MURTHO"
+          type: string
+        monitoringNetworkName:
+          description: "Name of monitoring network. Possible values: \r\n\r\nAngas\
+            \ Bremer PWA\r\n\r\nBarossa PWRA\r\n\r\nClare PWRA\r\n\r\nLeigh Creek\r\
+            \n\r\nLoxton - Bookpurnong Irrigation Areas\r\n\r\nWestern Mount Lofty\
+            \ Ranges PWRA\r\n\r\nLower Limestone Coast PWA_North\r\n\r\nBotanic Gardens\
+            \ wetlands\r\n\r\nSA Arid Lands Non-Prescribed Area\r\n\r\nNorthern Adelaide\
+            \ Plains Perched Aquifers\r\n\r\nPike Floodplain\r\n\r\nMallee PWA\r\n\
+            \r\nKatarapko Floodplain Injection\r\n\r\nBarossa irrigation wells salinity\
+            \ monitoring\r\n\r\nSA Murray Darling Basin Non-Prescribed Area\r\n\r\n\
+            Eastern Mount Lofty Ranges PWRA\r\n\r\nTatiara PWA\r\n\r\nPadthaway PWA\r\
+            \n\r\nPike and Murtho Irrigation Areas\r\n\r\nNorthern Adelaide Plains\
+            \ PWA irrigation wells salinity monitoring\r\n\r\nMcLaren Vale  PWA irrigation\
+            \ wells salinity monitoring\r\n\r\nAlinytjara Wilurara Non-Prescribed\
+            \ Area\r\n\r\nCentral Adelaide PWA\r\n\r\nMcLaren Vale PWA\r\n\r\nLower\
+            \ Limestone Coast PWA_South\r\n\r\nPeake, Roby and Sherlock PWA\r\n\r\n\
+            Golden Grove extractive indust zone\r\n\r\nSA Water Town Water Supplies\
+            \ salinity monitoring\r\n\r\nKangaroo Island Non-Prescribed Area\r\n\r\
+            \nNorthern & Yorke Non-Prescribed Area - SOUTH\r\n\r\nBerri and Renmark\
+            \ Irrigation Areas\r\n\r\nNorthern Adelaide Plains PWA\r\n\r\nSouthern\
+            \ Basins PWA\r\n\r\nKatarapko Floodplain\r\n\r\nWaikerie Moorook Irrigation\
+            \ Areas\r\n\r\nSA Water Murtho SIS\r\n\r\nSA Water Waikerie SIS\r\n\r\n\
+            Baroota PWRA\r\n\r\nKangaroo Flat irrigation wells salinity monitoring\r\
+            \n\r\nMusgrave PWA\r\n\r\nNorthern & Yorke Non-Prescribed Area - NORTH\r\
+            \n\r\nStreaky Bay Non-Prescribed Area\r\n\r\nSA Murray Darling Basin -\
+            \ SA Water\r\n\r\nEPNRM Groundwater Dependent Ecosystem wells\r\n\r\n\
+            Far North PWA\r\n\r\nSE Flows Restoration Project\r\n\r\nMarla Township\r\
+            \n\r\nMarne River and Saunders Creek PWRA\r\n\r\nChowilla Floodplain\r\
+            \n\r\nTintinara Coonalpyn PWA\r\n\r\nSouth East Non-Prescribed Area\r\n\
+            \r\nEyre Peninsula Non-Prescribed Area\r\n\r\nNoora Disposal Basin"
+          type: string
+      example:
+        monitoringNetworkCode: STHNBASINS
+        monitoringNetworkName: Southern Basins PWA
   responses:
     UnauthorizedError:
       headers:

--- a/sageodata-apispec.yml
+++ b/sageodata-apispec.yml
@@ -1,7 +1,7 @@
 ---
 openapi: 3.0.1
 info:
-  title: SA Geodata API
+  title: SA Geodata API - SWIMS Phase 1 changes
   version: "1.0"
   description: SA Geodata - Webservice API specification
   contact:
@@ -201,7 +201,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/welldriller-page'
-          description: Successful response - returns an array of `welldrillers` entities.
+          description: Successful response - returns a page of `welldrillers` entities.
       operationId: getwelldrillers
       summary: List All welldrillers
       description: Gets a list of all `welldrillers` entities.
@@ -951,116 +951,6 @@ components:
         pageNumber:
           description: Index (1-based) respresenting current page number
           type: integer
-    wcr-coordinatedata:
-      description: Well Completion Report - Coordinate Data
-      required:
-      - datum
-      - easting
-      - northing
-      - zone
-      type: object
-      properties:
-        datum:
-          description: "The coordinate system of the datum. \nPossible values: `WGS84`,\
-            \ `GDA94`, `GDA2020`"
-          enum:
-          - GDA94
-          - GDA2020
-          - WGS84
-          type: string
-        easting:
-          format: int32
-          description: Easting
-          type: integer
-        northing:
-          format: int32
-          description: Northing
-          type: integer
-        zone:
-          format: int32
-          description: Zone
-          type: integer
-        lat:
-          format: double
-          description: Latitude
-          type: number
-        long:
-          format: double
-          description: Longitude
-          type: number
-        surveyAccuracyInMetres:
-          format: double
-          description: Survey Accuracy in meters
-          type: number
-        surveyMethod:
-          description: "Survey Method. Possible values: \n\n`AMGRD` - Controlled AMG/MGA\
-            \ map\t\n`CAL` - (DISUSED) Calculated\t\n`CLGRD` - Controlled CLARKE map\t\
-            \n`COCH` - (DISUSED) Compass and Chain\t\n`COOD` - (DISUSED) Compass and\
-            \ Odometer\t\n`DEM` - Digital Elevation Model\t\n`DIG` - Digitised\t\n\
-            `DOCM` - Sourced from documents (PLANS, ENV, RB,etc)\t\n`EDM` - (DISUSED)\
-            \ EDM\t\n`GCN` - (DISUSED) MESA Geog conversion from Clarke coords\t\n\
-            `GISP` - GIS software on PDA or similar mobile device\t\n`GISW` - GIS\
-            \ software on full Windows OS PC\t\n`GOEAR` - Google Earth image\t\n`GOMAP`\
-            \ - Google Maps image\t\n`GPS` - (DISUSED, use GPSUN) Global Positioning\
-            \ System\t\n`GPSAP` - GPS Averaged Position\t\n`GPSAU` - GPS Post Processed\
-            \ Using AUSPOS Service\t\n`GPSDG` - GPS Differential Generic\t\n`GPSDM`\
-            \ - GPS Multi Base Wide Area Differential (was GPSPD)\t\n`GPSDS` - GPS\
-            \ Single Base Wide Area Differential (was GPSRD)\t\n`GPSPD` - GPS Post\
-            \ Processed Differential (nav level)\t\n`GPSRD` - GPS Real-time Differential\
-            \ (nav level)\t\n`GPSSK` - GPS Svy Grade- Real Time Kinematic (RTK)/Kinematic\t\
-            \n`GPSSL` - GPS Survey Grade (kinematic/static)\t\n`GPSSN` - GPS Standalone\
-            \ Navigational\t\n`GPSSS` - GPS Survey Grade - Static\t\n`GPSUN` - GPS\
-            \ type unknown\t\n`GTRAV` - Interpolated traverse site between GPS endpoints\t\
-            \n`IMGD` - Digital Image\t\n`INFER` - (DISUSED) Inferred\t\n`LOCAL` -\
-            \ (DISUSED) Approximate local methods\t\n`MAP` - (DISUSED) Map Plot\t\n\
-            `ODOM` - (DISUSED) Odometer\t\n`PHOTO` - Air Photo\t\n`PRO` - (DISUSED)\
-            \ Provisional (Estimated)\t\n`SAN` - (DISUSED) Santos conversion from\
-            \ Clarke coords\t\n`SUR` - Surveying\t\n`TRX` - GDA94 Transformed\t\n\
-            `UCMAP` - Uncontrolled map\t\n`UKN` - (DISUSED) Unknown\t\n`VERBL` - (DISUSED)\
-            \ Verbal"
-          enum:
-          - AMGRD
-          - CAL
-          - CLGRD
-          - COCH
-          - COOD
-          - DEM
-          - DIG
-          - DOCM
-          - EDM
-          - GCN
-          - GISP
-          - GISW
-          - GOEAR
-          - GOMAP
-          - GPS
-          - GPSAP
-          - GPSAU
-          - GPSDG
-          - GPSDM
-          - GPSDS
-          - GPSPD
-          - GPSRD
-          - GPSSK
-          - GPSSL
-          - GPSSN
-          - GPSSS
-          - GPSUN
-          - GTRAV
-          - IMGD
-          - INFER
-          - LOCAL
-          - MAP
-          - ODOM
-          - PHOTO
-          - PRO
-          - SAN
-          - SUR
-          - TRX
-          - UCMAP
-          - UKN
-          - VERBL
-          type: string
     wcr-drillingdata:
       description: Well Completion Report - Drilling Data
       required:
@@ -2472,6 +2362,125 @@ components:
         comments: South Western Mining Company
         createdDate: 1992-12-10T18:04:24.000Z
         modifiedDate: 2019-08-30T09:32:00.000Z
+    coordinatedata:
+      description: Coordinate Data
+      required:
+      - datum
+      - easting
+      - northing
+      - zone
+      type: object
+      properties:
+        datum:
+          description: "The coordinate system of the datum. \nPossible values: `WGS84`,\
+            \ `GDA94`, `GDA2020`"
+          enum:
+          - GDA94
+          - GDA2020
+          - WGS84
+          type: string
+        easting:
+          format: int32
+          description: Easting
+          type: integer
+        northing:
+          format: int32
+          description: Northing
+          type: integer
+        zone:
+          format: int32
+          description: Zone
+          type: integer
+        lat:
+          format: double
+          description: Latitude
+          type: number
+        long:
+          format: double
+          description: Longitude
+          type: number
+    wcr-coordinatedata:
+      description: Well Completion Report - Coordinate Data
+      required:
+      - coordinateData
+      type: object
+      properties:
+        coordinateData:
+          $ref: '#/components/schemas/coordinatedata'
+          description: Coordinate-data
+        surveyAccuracyInMetres:
+          format: double
+          description: Survey Accuracy in meters
+          type: number
+        surveyMethod:
+          description: "Survey Method. Possible values: \n\n`AMGRD` - Controlled AMG/MGA\
+            \ map\t\n`CAL` - (DISUSED) Calculated\t\n`CLGRD` - Controlled CLARKE map\t\
+            \n`COCH` - (DISUSED) Compass and Chain\t\n`COOD` - (DISUSED) Compass and\
+            \ Odometer\t\n`DEM` - Digital Elevation Model\t\n`DIG` - Digitised\t\n\
+            `DOCM` - Sourced from documents (PLANS, ENV, RB,etc)\t\n`EDM` - (DISUSED)\
+            \ EDM\t\n`GCN` - (DISUSED) MESA Geog conversion from Clarke coords\t\n\
+            `GISP` - GIS software on PDA or similar mobile device\t\n`GISW` - GIS\
+            \ software on full Windows OS PC\t\n`GOEAR` - Google Earth image\t\n`GOMAP`\
+            \ - Google Maps image\t\n`GPS` - (DISUSED, use GPSUN) Global Positioning\
+            \ System\t\n`GPSAP` - GPS Averaged Position\t\n`GPSAU` - GPS Post Processed\
+            \ Using AUSPOS Service\t\n`GPSDG` - GPS Differential Generic\t\n`GPSDM`\
+            \ - GPS Multi Base Wide Area Differential (was GPSPD)\t\n`GPSDS` - GPS\
+            \ Single Base Wide Area Differential (was GPSRD)\t\n`GPSPD` - GPS Post\
+            \ Processed Differential (nav level)\t\n`GPSRD` - GPS Real-time Differential\
+            \ (nav level)\t\n`GPSSK` - GPS Svy Grade- Real Time Kinematic (RTK)/Kinematic\t\
+            \n`GPSSL` - GPS Survey Grade (kinematic/static)\t\n`GPSSN` - GPS Standalone\
+            \ Navigational\t\n`GPSSS` - GPS Survey Grade - Static\t\n`GPSUN` - GPS\
+            \ type unknown\t\n`GTRAV` - Interpolated traverse site between GPS endpoints\t\
+            \n`IMGD` - Digital Image\t\n`INFER` - (DISUSED) Inferred\t\n`LOCAL` -\
+            \ (DISUSED) Approximate local methods\t\n`MAP` - (DISUSED) Map Plot\t\n\
+            `ODOM` - (DISUSED) Odometer\t\n`PHOTO` - Air Photo\t\n`PRO` - (DISUSED)\
+            \ Provisional (Estimated)\t\n`SAN` - (DISUSED) Santos conversion from\
+            \ Clarke coords\t\n`SUR` - Surveying\t\n`TRX` - GDA94 Transformed\t\n\
+            `UCMAP` - Uncontrolled map\t\n`UKN` - (DISUSED) Unknown\t\n`VERBL` - (DISUSED)\
+            \ Verbal"
+          enum:
+          - AMGRD
+          - CAL
+          - CLGRD
+          - COCH
+          - COOD
+          - DEM
+          - DIG
+          - DOCM
+          - EDM
+          - GCN
+          - GISP
+          - GISW
+          - GOEAR
+          - GOMAP
+          - GPS
+          - GPSAP
+          - GPSAU
+          - GPSDG
+          - GPSDM
+          - GPSDS
+          - GPSPD
+          - GPSRD
+          - GPSSK
+          - GPSSL
+          - GPSSN
+          - GPSSS
+          - GPSUN
+          - GTRAV
+          - IMGD
+          - INFER
+          - LOCAL
+          - MAP
+          - ODOM
+          - PHOTO
+          - PRO
+          - SAN
+          - SUR
+          - TRX
+          - UCMAP
+          - UKN
+          - VERBL
+          type: string
   responses:
     UnauthorizedError:
       headers:


### PR DESCRIPTION
Changes required for development of SAGeoData -> SWIMS interface. Mostly additions to the obswell object, and a new object and endpoint for obswell notes.

Note - considered using wcr-coordinatedata object instead of easting, northing, zone etc. in obswell object, but wcr-coordinatedata has some properties that are possibly not relevant in the obswell context (such as survey method). Suggest possibly create a more generic 'coordinatedata' object which wcr-coordinatedata could inherit from?